### PR TITLE
sound: soc: msm8996: Fix wrong array size

### DIFF
--- a/sound/soc/msm/msm8996.c
+++ b/sound/soc/msm/msm8996.c
@@ -2026,8 +2026,8 @@ static const struct soc_enum msm8996_mi2s_snd_enum[] = {
 	SOC_ENUM_SINGLE_EXT(4, sec_mi2s_tx_ch_text),
 	SOC_ENUM_SINGLE_EXT(4, tert_mi2s_rx_ch_text),
 	SOC_ENUM_SINGLE_EXT(4, tert_mi2s_tx_ch_text),
-	SOC_ENUM_SINGLE_EXT(8, quat_mi2s_rx_ch_text),
-	SOC_ENUM_SINGLE_EXT(8, quat_mi2s_tx_ch_text),
+	SOC_ENUM_SINGLE_EXT(4, quat_mi2s_rx_ch_text),
+	SOC_ENUM_SINGLE_EXT(4, quat_mi2s_tx_ch_text),
 };
 
 static int msm_slim_5_rx_be_hw_params_fixup(struct snd_soc_pcm_runtime *rtd,


### PR DESCRIPTION
OnePlus reduced the size of an array from 8 to 4 but didn't adjust
the function that allocates it so it tried to allocate nothing and
tripped.

quat_mi2s_rx_ch_text and quat_mi2s_tx_ch_text actually has 4 members
instead of 8.

Signed-off-by: Yaroslav Furman <yaro330@gmail.com>
Change-Id: I158886ac5010ebd1f430779a65808a40d2d757d6